### PR TITLE
Use generic path param for functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,3 @@ jobs:
   - stage: unittest
     script:
     - cargo test --verbose
-    - rm -rf $TMPDIR/mmv-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: rust
+
+rust:
+  - stable
+
+cache: cargo
+
+jobs:
+  - stage: unittest
+    script:
+    - cargo test --verbose
+    - rm -rf $TMPDIR/mmv-tests

--- a/src/filepath/mod.rs
+++ b/src/filepath/mod.rs
@@ -69,23 +69,24 @@ pub fn from_slash(path: &Path) -> PathBuf {
     PathBuf::from(new_path)
 }
 
-pub fn clean(path: &Path) -> PathBuf {
-    let path_str = match path.to_str() {
-        Some(_path_str) => _path_str,
-        None => "",
-    };
-    let path_vec = path_str.chars().collect::<Vec<char>>();
-    let vol_len = volume_name_len(path);
+pub fn clean<P: AsRef<Path>>(path: P) -> PathBuf {
+    let path_vec = path
+        .as_ref()
+        .to_str()
+        .unwrap()
+        .chars()
+        .collect::<Vec<char>>();
+    let vol_len = volume_name_len(path.as_ref());
     let path_without_vol = &path_vec[vol_len..path_vec.len()];
 
     if path_without_vol.is_empty() {
         if vol_len > 1 && path_vec[1] != ':' {
             // UNC pathing probably.
-            return from_slash(path);
+            return from_slash(path.as_ref());
         }
 
         // For empty paths, return prefix + ".".
-        let mut new_path = path.to_path_buf();
+        let mut new_path = path.as_ref().to_path_buf();
         new_path.push(".");
         return new_path;
     }

--- a/src/filepath/mod.rs
+++ b/src/filepath/mod.rs
@@ -235,8 +235,7 @@ fn test_clean() {
         ];
 
         for (path_str, expected_output) in path_strs.iter() {
-            let path = Path::new(path_str);
-            assert_eq!(clean(path).to_str(), Some(*expected_output));
+            assert_eq!(clean(path_str).to_str(), Some(*expected_output));
         }
     }
 }

--- a/src/filepath/mod.rs
+++ b/src/filepath/mod.rs
@@ -48,20 +48,21 @@ pub fn is_path_separator(c: char) -> bool {
     false
 }
 
-pub fn volume_name_len(path: &Path) -> usize {
+pub fn volume_name_len<P: AsRef<Path>>(path: P) -> usize {
     if cfg!(windows) {
-        return windows::volume_name_len(path);
+        return windows::volume_name_len(path.as_ref());
     }
 
     0
 }
 
-pub fn from_slash(path: &Path) -> PathBuf {
+pub fn from_slash<P: AsRef<Path>>(path: P) -> PathBuf {
     if os_separator() == '/' {
-        return path.to_path_buf();
+        return path.as_ref().to_path_buf();
     }
 
     let new_path = path
+        .as_ref()
         .to_str()
         .unwrap()
         .replace("/", &os_separator().to_string());

--- a/src/mmv/mod.rs
+++ b/src/mmv/mod.rs
@@ -121,8 +121,8 @@ fn build_renames(files: &HashMap<PathBuf, PathBuf>) -> Result<Vec<Edge>, String>
             return Err(EMPTY_PATH_ERROR.to_string());
         }
 
-        let cleaned_src = clean(src.as_path());
-        let cleaned_dst = clean(dst.as_path());
+        let cleaned_src = clean(src);
+        let cleaned_dst = clean(dst);
 
         if file_map.contains_key(&cleaned_src) {
             return Err(format!("Duplicate source {}", cleaned_src.display()));
@@ -306,7 +306,7 @@ mod tests {
                     }
                 } else {
                     // Write file contents to output map
-                    let cleaned_path = clean(pathbuf.as_path());
+                    let cleaned_path = clean(pathbuf);
                     let read_result = fs::read(&cleaned_path);
                     let contents = String::from_utf8(read_result?);
                     if contents.is_ok() {

--- a/src/mmv/mod.rs
+++ b/src/mmv/mod.rs
@@ -105,7 +105,7 @@ fn do_rename(src: &Path, dst: &Path) -> Result<(), io::Error> {
 /// So when adding back the edges to the output vector, the edges are pushed
 /// in reverse so that the files can be `moved` without overriding the contents
 /// of other files.
-fn build_renames(files: &HashMap<PathBuf, PathBuf>) -> Result<Vec<Edge>, String> {
+fn build_renames<P: AsRef<Path>>(files: &HashMap<P, P>) -> Result<Vec<Edge>, String> {
     // Represents the reverse of files - where all edges are reversed.
     // Eg. A -> B becomes B -> A
     let mut rev = HashMap::<PathBuf, PathBuf>::new();
@@ -117,7 +117,7 @@ fn build_renames(files: &HashMap<PathBuf, PathBuf>) -> Result<Vec<Edge>, String>
     // Raise error if src/dst are repeated.
     // Also construct file_map and rev along on the way.
     for (src, dst) in files {
-        if src.to_str() == Some("") || dst.to_str() == Some("") {
+        if src.as_ref().to_str() == Some("") || dst.as_ref().to_str() == Some("") {
             return Err(EMPTY_PATH_ERROR.to_string());
         }
 

--- a/src/mmv/mod.rs
+++ b/src/mmv/mod.rs
@@ -14,7 +14,7 @@ pub struct Edge {
     pub dst: PathBuf,
 }
 
-pub fn rename(files: &HashMap<PathBuf, PathBuf>, dir: Option<&str>) -> Result<(), String> {
+pub fn rename<P: AsRef<Path>>(files: &HashMap<P, P>, dir: Option<&str>) -> Result<(), String> {
     let mut dir_path = "";
     if dir.is_some() {
         dir_path = dir.unwrap();


### PR DESCRIPTION
Replace instances of `func(path: &Path)` with `func<P: AsRef<Path>>(path: P)`. This way, you can call `func(path)` or `func(pathbuf)` interchangeably.

Also, provide basic CI to run tests.